### PR TITLE
Support DP for ViT in qwen2.5vl

### DIFF
--- a/vllm_ascend/models/qwen2_5_vl.py
+++ b/vllm_ascend/models/qwen2_5_vl.py
@@ -39,8 +39,8 @@ from vllm.model_executor.models.qwen2_5_vl import (
     Qwen2_5_VisionRotaryEmbedding, Qwen2_5_VisionTransformer,
     Qwen2_5_VLDummyInputsBuilder, Qwen2_5_VLForConditionalGeneration,
     Qwen2_5_VLMultiModalProcessor, Qwen2_5_VLProcessingInfo)
-from vllm.model_executor.models.utils import (maybe_prefix,
-                                              run_dp_sharded_mrope_vision_model)
+from vllm.model_executor.models.utils import maybe_prefix
+from vllm.multimodal.utils import run_dp_sharded_mrope_vision_model
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
 MIN_PAD_SIZE = 64  # min_size to pad weight

--- a/vllm_ascend/models/qwen2_5_vl.py
+++ b/vllm_ascend/models/qwen2_5_vl.py
@@ -395,11 +395,20 @@ class AscendQwen2_5_VisionTransformer(Qwen2_5_VisionTransformer):
         window_index = torch.cat(window_index, dim=0)
         return window_index, cu_window_seqlens
 
+    def _normalize_grid_thw(self, grid_thw: Union[torch.Tensor, list[list[int]]]) -> torch.Tensor:
+        if isinstance(grid_thw, list):
+            grid_thw = torch.tensor(grid_thw, device=self.device)
+        elif not isinstance(grid_thw, torch.Tensor):
+            raise TypeError(f"Expected input type is torch.Tensor or list of lists, got {type(grid_thw)}")
+        return grid_thw
+
     def forward(
         self,
         x: torch.Tensor,
-        grid_thw: torch.Tensor,
+        grid_thw: Union[torch.Tensor, list[list[int]]],
     ) -> torch.Tensor:
+        # normalize grid_thw to aviod type conflict
+        grid_thw = self._normalize_grid_thw(grid_thw)
         # compute cu_seqlens
         cu_seqlens = torch.repeat_interleave(grid_thw[:, 1] * grid_thw[:, 2],
                                              grid_thw[:,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.
- Fixes #

-->
Add DP (Data Parallelism) support for ViT in Qwen2.5VL, achieving over 10% speedup.
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
No
### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
vllm:0.10.0RC1
vllm-ascend:0.10.0RC1
benchmark test
```
**Test Plan**
export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
vllm serve \
    /workspace/models/Qwen2.5-VL-3B-Instruct \
    --port 5580 --host 0.0.0.0 \
    --max-num-seqs 128 --dtype bfloat16 --max-model-len=8192 \
    --no-enable-prefix-caching --trust-remote-code -tp 4 \
    --allowed-local-media-path /workspace/l00807937/ \
    --gpu-memory-utilization=0.93 \
    --enforce-eager \
    --mm-encoder-tp-mode data

**Test Result**
baseline: without --mm-encoder-tp-mode data
============ Serving Benchmark Result ============
Successful requests:                     99        
Benchmark duration (s):                  28.79     
Total input tokens:                      9959      
Total generated tokens:                  10707     
Request throughput (req/s):              3.44      
Output token throughput (tok/s):         371.96    
Total Token throughput (tok/s):          717.94    
---------------Time to First Token----------------
Mean TTFT (ms):                          7711.37   
Median TTFT (ms):                        6832.34   
P99 TTFT (ms):                           17305.82  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          177.03    
Median TPOT (ms):                        161.73    
P99 TPOT (ms):                           413.63    
---------------Inter-token Latency----------------
Mean ITL (ms):                           157.30    
Median ITL (ms):                         90.89     
P99 ITL (ms):                            640.97    
==================================================
DP4: with --mm-encoder-tp-mode data
============ Serving Benchmark Result ============
Successful requests:                     99        
Benchmark duration (s):                  25.67     
Total input tokens:                      9959      
Total generated tokens:                  10749     
Request throughput (req/s):              3.86      
Output token throughput (tok/s):         418.82    
Total Token throughput (tok/s):          806.85    
---------------Time to First Token----------------
Mean TTFT (ms):                          6393.85   
Median TTFT (ms):                        5437.94   
P99 TTFT (ms):                           14115.35  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          158.26    
Median TPOT (ms):                        150.12    
P99 TPOT (ms):                           346.36    
---------------Inter-token Latency----------------
Mean ITL (ms):                           140.90    
Median ITL (ms):                         90.94     
P99 ITL (ms):                            439.49    
==================================================
```