### PR TITLE
Issue 2607 fix bug in test

### DIFF
--- a/tests/ut/models/test_qwen2_5_vl.py
+++ b/tests/ut/models/test_qwen2_5_vl.py
@@ -169,7 +169,8 @@ class TestAscendQwen2_5_VisionBlock(PytestBase):
             mlp_hidden_dim=mlp_hidden_dim,
         )
         args, kwargs = mocker_vit.call_args
-        assert args == (dim, num_heads, mlp_hidden_dim, F.silu, None, None, "", False)
+        assert args == (dim, num_heads, mlp_hidden_dim, F.silu, None, None, "",
+                        False)
         assert not kwargs
 
         args1, kwargs1 = mocker_attn.call_args

--- a/tests/ut/models/test_qwen2_5_vl.py
+++ b/tests/ut/models/test_qwen2_5_vl.py
@@ -32,7 +32,7 @@ class TestAscendQwen2_5_VisionAttention(PytestBase):
             prefix=prefix,
         )
         args, kwargs = mocker_attn.call_args
-        assert args == (embed_dim, num_heads, projection_size, None, "")
+        assert args == (embed_dim, num_heads, projection_size, None, "", False)
         assert not kwargs
         attention.num_attention_heads_per_partition = num_heads
         return attention
@@ -169,7 +169,7 @@ class TestAscendQwen2_5_VisionBlock(PytestBase):
             mlp_hidden_dim=mlp_hidden_dim,
         )
         args, kwargs = mocker_vit.call_args
-        assert args == (dim, num_heads, mlp_hidden_dim, F.silu, None, None, "")
+        assert args == (dim, num_heads, mlp_hidden_dim, F.silu, None, None, "", False)
         assert not kwargs
 
         args1, kwargs1 = mocker_attn.call_args
@@ -180,6 +180,7 @@ class TestAscendQwen2_5_VisionBlock(PytestBase):
             "projection_size": dim,
             "quant_config": None,
             "prefix": ".attn",
+            "use_data_parallel": False,
         }
         return vision_block
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
fix bug in test
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
No
### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
(py311) [root@devserver-bms-89 vllm-ascend-lhs]# pytest -s tests/ut/models/test_qwen2_5_vl.py
INFO 09-05 10:55:15 [init.py:36] Available plugins for group vllm.platform_plugins:
INFO 09-05 10:55:15 [init.py:38] - ascend -> vllm_ascend:register
INFO 09-05 10:55:15 [init.py:41] All plugins in this group will be loaded. Set VLLM_PLUGINS to control which plugins to load.
INFO 09-05 10:55:15 [init.py:232] Platform plugin ascend is activated
WARNING 09-05 10:55:15 [_custom_ops.py:20] Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
INFO 09-05 10:55:16 [importing.py:63] Triton not installed or not compatible; certain GPU-related functions will not be available.
==================== =========test session starts=============================
platform linux -- Python 3.11.13, pytest-8.4.1, pluggy-1.6.0
rootdir: /workspace/l00807937/DP_for_ViT/vllm-ascend-lhs
configfile: pyproject.toml
plugins: mock-3.14.1, anyio-4.9.0, typeguard-4.3.0
collected 13 items

tests/ut/models/test_qwen2_5_vl.py ........WARNING 09-05 10:55:16 [init.py:3984] Current vLLM config is not set.
WARNING 09-05 10:55:16 [platform.py:135] Model config is missing. This may indicate that we are running a test case
WARNING 09-05 10:55:16 [platform.py:162] compilation_config.level = CompilationLevel.NO_COMPILATION is set, Setting CUDAGraphMode to NONE
.....

==================== ========= 13 passed in 0.79s=============================
(py311) [root@devserver-bms-89 vllm-ascend-lhs]# pytest tests/ut/test_platform.py::TestNPUPlatform::test_check_and_update_config_no_model_config_warning
==================== =========test session starts=============================
platform linux -- Python 3.11.13, pytest-8.4.1, pluggy-1.6.0
rootdir: /workspace/l00807937/DP_for_ViT/vllm-ascend-lhs
configfile: pyproject.toml
plugins: mock-3.14.1, anyio-4.9.0, typeguard-4.3.0
collected 1 item

tests/ut/test_platform.py . [100%]