### PR TITLE
[Feature]: Add ViT memory/latency metrics, LLM prefill/decode latency, and TTFT tracing with environment switches

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -372,7 +372,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
             dtype=torch.bool,
             device=self.device,
         )
-        # ---------------- NEW: Timing related switches and data structures ----------------
+        # ---------------- Timing related switches and data structures ----------------
         # Switch for basic timing of multimodal and LLM stages
         self.enable_mm_timing = bool(int(os.environ.get("VLLM_ASCEND_MM_TIMING", "0")))
         # measure TTFT
@@ -986,7 +986,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
             # 2. A list or tuple (length: num_items) of tensors, each of shape
             # (feature_size, hidden_size) in case the feature size is dynamic
             # depending on the input multimodal items.
-            
+
             # NPU Event: record the encoding section
             if self.enable_mm_timing:
                 enc_start_evt = torch.npu.Event(enable_timing=True)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
To profile and tune multimodal (ViT) + LLM pipelines on Ascend, we need first-class metrics for:

ViT (multimodal encoder) memory requirement
ViT latency
LLM prefill and decode latency
TTFT (Time-To-First-Token)
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
No
### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
python /workspace/l00807937/DP_for_ViT/vllm-main/benchmarks/benchmark_serving.py   --backend openai-chat   --endpoint /v1/chat/completions   --model /workspace/models/Qwen2.5-VL-7B-Instruct   --trust_remote_code   --port 5580   --host 127.0.0.1   --dataset-name hf    --dataset-path lmarena-ai/VisionArena-Chat   --num-prompts 200   --max_concurrency 64   --seed 40


<img width="752" height="452" alt="image" src="https://github.com/user-attachments/assets/8a943db3-94c0-4965-aad2-de256c58c622" />

BatchSize | 1 | 2 | 4 | 8 | 16 | 32
-- | -- | -- | -- | -- | -- | --
内存需求(MB) | 970 | 968.52 | 964.88 | 1920.59 | 1931.43 | 2870.15

<img width="751" height="509" alt="image" src="https://github.com/user-attachments/assets/d13e185b-bd92-4fa9-b89d-a3000fe305ea" />


BatchSize | 1 | 2 | 4 | 8 | 16 | 32
-- | -- | -- | -- | -- | -- | --
ViT时延(ms) | 62.71 | 62.8 | 60.74 | 62.32 | 68 | 74.45


<img width="752" height="452" alt="image" src="https://github.com/user-attachments/assets/656ac102-a5cc-4f97-8ad4-0e1455d0bbdb" />

BatchSize | 1 | 2 | 4 | 8 | 16 | 32
-- | -- | -- | -- | -- | -- | --
prefill时延(ms) | 91.51 | 92.9 | 104.43 | 107.44 | 116.12 | 124.78

<img width="752" height="509" alt="image" src="https://github.com/user-attachments/assets/cd7fc2ae-75cd-4a65-b8d0-b076aaba69c6" />

BatchSize | 1 | 2 | 4 | 8 | 16 | 32
-- | -- | -- | -- | -- | -- | --
decode时延(ms) | 47.3 | 49.73 | 49.76 | 61.17 | 83.69 | 85.23

<img width="1433" height="533" alt="image" src="https://github.com/user-attachments/assets/aadf8314-52c2-4f45-bf4b-6200d82b7cdc" />

BatchSize | 1 | 2 | 4 | 8 | 16 | 32
-- | -- | -- | -- | -- | -- | --
queue_wait_ms | 0.29 | 0.26 | 0.37 | 2.81 | 31.33 | 193.58
update_states_ms | 1.77 | 1.58 | 1.73 | 1.80 | 2.00 | 2.42
prepare_inputs_ms | 45.57 | 57.23 | 59.00 | 60.31 | 64.67 | 71.12
encoder_ms | 62.46 | 58.92 | 65.57 | 68.04 | 73.92 | 83.43
prefill_ms | 89.18 | 95.75 | 106.45 | 111.13 | 115.95 | 127.18
sampling_ms | 1.23 | 1.15 | 1.73 | 1.72 | 2.04 | 3.42
compute_logits_ms | 1.82 | 1.83 | 2.02 | 2.00 | 2.01 | 2.07
post_process_ms | 0.22 | 0.24 | 0.26 | 0.29 | 0.35 | 0.46
ttft_total | 203.27 | 217.69 | 237.81 | 248.72 | 292.82 | 484.19
