### PR TITLE
EPD Feature modified from v0.9.1 to v0.11.0

### DIFF
--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -29,8 +29,11 @@ from torch_npu.profiler import dynamic_profile as dp
 from vllm.config import VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment)
-from vllm.distributed.kv_transfer import ensure_kv_transfer_initialized
-from vllm.distributed.parallel_state import get_pp_group, get_tp_group
+from vllm.distributed.parallel_state import (get_pp_group, get_tp_group, 
+                        init_distributed_environment, set_custom_all_reduce)
+from vllm.distributed.ec_transfer import ensure_ec_transfer_initialized
+from vllm.distributed.kv_transfer import (ensure_kv_transfer_initialized,
+                                          has_kv_transfer_group)
 from vllm.logger import logger
 from vllm.lora.request import LoRARequest
 from vllm.sequence import IntermediateTensors
@@ -368,6 +371,7 @@ class NPUWorker(WorkerBase):
             self.parallel_config.pipeline_parallel_size)
         init_ascend_model_parallel(self.parallel_config)
         ensure_kv_transfer_initialized(self.vllm_config)
+        ensure_ec_transfer_initialized(self.vllm_config)
 
     def _init_profiler(self):
         # Torch profiler. Enabled and configured through env vars:


### PR DESCRIPTION
✅ Summary

This PR migrates the EPD separation and multi-modal KV-cache reuse features from vllm-ascend@v0.9.1 to v0.11.0, enabling full compatibility with the newer vLLM architecture and executor changes introduced after 0.10.x. The goal is to preserve the original optimization for Ascend devices while aligning with the updated scheduler / executor / cache manager design of upstream 0.11.0.